### PR TITLE
Calling correct args for new CAN Message

### DIFF
--- a/j1939/electronic_control_unit.py
+++ b/j1939/electronic_control_unit.py
@@ -576,7 +576,7 @@ class ElectronicControlUnit(object):
 
         if not self._bus:
             raise RuntimeError("Not connected to CAN bus")
-        msg = can.Message(extended_id=True,
+        msg = can.Message(is_extended_id=True,
                           arbitration_id=can_id,
                           data=data
                           )


### PR DESCRIPTION
Due to updates in the [pycan](https://github.com/hardbyte/python-can/pull/413) library sending messages are broken. The `extended_id` is deprecated in removed in pycan 4.0.

This PR is to update the code to be compatible with the changes. 